### PR TITLE
Add geo location overwrite

### DIFF
--- a/lib/EventRider.js
+++ b/lib/EventRider.js
@@ -26,6 +26,8 @@ module.exports = class GoogleAnalyticsEventRider {
 
     if (voxaEvent.request.locale) {
       this.visitor.set('ul', voxaEvent.request.locale.toLowerCase());
+      const countryCode = voxaEvent.request.locale.split('-')[0];
+      this.visitor.set('geoid', countryCode.toUpperCase());
     }
     this.visitor.set('ds', `${this.config.appName}@${this.config.appVersion}`);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voxa-ga",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Integrate Google Universal Analytics into your Alexa apps using the voxa framework",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Users coming from other countries were being logged as visits from the US. This fixes that. following GA docs for this: https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#geoid